### PR TITLE
VORGテーブルのデータ取得用プロパティーを追加

### DIFF
--- a/MODIFICATIONS.md
+++ b/MODIFICATIONS.md
@@ -2,4 +2,6 @@
 
 ## [Unreleased]
 
-- (to be added)
+- Add properties to get the origin Y coordinate in the vertical writing mode:
+    - `TTFFont#defaultVertOriginY`
+    - `Glyph#vertOriginY`

--- a/MODIFICATIONS.md
+++ b/MODIFICATIONS.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
-- Add properties to get the origin Y coordinate in the vertical writing mode:
+- Add properties to get the glyph's origin Y coordinate in the vertical writing mode:
     - `TTFFont#defaultVertOriginY`
+    - `TTFFont#getVertOriginYMap`
     - `Glyph#vertOriginY`

--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -555,14 +555,16 @@ export default class TTFFont {
   /**
    * The default origin Y coordinate of the glyphs in the vertical writing mode.
    *
-   * `undefined` if `VORG` table does not exist.
+   * `null` if `VORG` table does not exist.
    *
    * See also `Glyph#vertOriginY` for a value specific to a particular glyph.
    *
-   * @type {number | undefined}
+   * @type {number | null}
    * @see VORG https://learn.microsoft.com/en-us/typography/opentype/spec/vorg
    */
   get defaultVertOriginY() {
-    return this.VORG?.defaultVertOriginY;
+    const { VORG } = this;
+
+    return VORG != null ? VORG.defaultVertOriginY : null;
   }
 }

--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -551,4 +551,16 @@ export default class TTFFont {
   getFont(name) {
     return this.getVariation(name);
   }
+
+  /**
+   * The default origin Y coordinate of the glyphs in this font.
+   * 
+   * See also `Glyph#vertOriginY` for a value specific to a particular glyph.
+   *
+   * @type {number | undefined}
+   * @see VORG https://learn.microsoft.com/en-us/typography/opentype/spec/vorg
+   */
+  get defaultVertOriginY() {
+    return this.VORG?.defaultVertOriginY;
+  }
 }

--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -567,4 +567,24 @@ export default class TTFFont {
 
     return VORG != null ? VORG.defaultVertOriginY : null;
   }
+
+  /**
+   * Returns a mapping from glyph IDs to the origin Y coordinate for each glyph in the vertical writing mode.
+   * 
+   * Returns `null` if `VORG` table does not exist.
+   * 
+   * @returns {Map<number, number> | null}
+   */
+  getVertOriginYMap() {
+    if (this._vertOriginYMap !== undefined) return this._vertOriginYMap;
+
+    if (this.VORG?.metrics == null) return this._vertOriginYMap = null;
+
+    const map = new Map();
+    for (const entry of this.VORG.metrics) {
+      map.set(entry.glyphIndex, entry.vertOriginY);
+    }
+
+    return this._vertOriginYMap = map;
+  }
 }

--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -563,9 +563,7 @@ export default class TTFFont {
    * @see VORG https://learn.microsoft.com/en-us/typography/opentype/spec/vorg
    */
   get defaultVertOriginY() {
-    const { VORG } = this;
-
-    return VORG != null ? VORG.defaultVertOriginY : null;
+    return this.VORG?.defaultVertOriginY ?? null;
   }
 
   /**

--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -553,8 +553,10 @@ export default class TTFFont {
   }
 
   /**
-   * The default origin Y coordinate of the glyphs in this font.
-   * 
+   * The default origin Y coordinate of the glyphs in the vertical writing mode.
+   *
+   * `undefined` if `VORG` table does not exist.
+   *
    * See also `Glyph#vertOriginY` for a value specific to a particular glyph.
    *
    * @type {number | undefined}

--- a/src/glyph/Glyph.js
+++ b/src/glyph/Glyph.js
@@ -165,13 +165,13 @@ export default class Glyph {
    * @see VORG https://learn.microsoft.com/en-us/typography/opentype/spec/vorg
    */
   get vertOriginY() {
-    let value = this._vertOriginY;
-    if (value !== undefined) return value;
-
+    // No cache needed here since getVertOriginYMap() has cache mechanism
     const map = this._font.getVertOriginYMap();
-    if (map != null) value = map.get(this.id);
-
-    return this._vertOriginY = value ?? null;
+    if (map != null) {
+      return map.get(this.id) ?? null;
+    } else {
+      return null;
+    }
   }
 
   get ligatureCaretPositions() {}

--- a/src/glyph/Glyph.js
+++ b/src/glyph/Glyph.js
@@ -156,7 +156,7 @@ export default class Glyph {
   }
 
   /**
-   * The glyph's origin Y coordinate.
+   * The glyph's origin Y coordinate in the vertical writing mode.
    *
    * `undefined` if no specific value is registered for this glyph.
    * See also `TTFFont#defaultVertOriginY` in that case.

--- a/src/glyph/Glyph.js
+++ b/src/glyph/Glyph.js
@@ -158,26 +158,31 @@ export default class Glyph {
   /**
    * The glyph's origin Y coordinate in the vertical writing mode.
    *
-   * `undefined` if no specific value is registered for this glyph.
+   * `null` if no specific value is registered for this glyph.
    * See also `TTFFont#defaultVertOriginY` in that case.
    * 
-   * @type {number | undefined}
+   * @type {number | null}
    * @see VORG https://learn.microsoft.com/en-us/typography/opentype/spec/vorg
    */
   get vertOriginY() {
-    if (this._vertOriginY) { return this._vertOriginY; }
+    let value = this._vertOriginY;
+    if (value !== undefined) return value;
 
     const { VORG } = this._font;
-    if (!VORG) return undefined;
-    const { metrics } = VORG;
-    if (!metrics) return undefined;
-
-    const { id } = this;
-    for (const entry of metrics) {
-      if (entry.glyphIndex === id) return this._vertOriginY = entry.vertOriginY;
+    if (VORG != null) {
+      const { metrics } = VORG;
+      if (metrics != null) {
+        const { id } = this;
+        for (const entry of metrics) {
+          if (entry.glyphIndex === id) {
+            value = entry.vertOriginY;
+            break;
+          }
+        }
+      }
     }
-
-    return undefined;
+      
+    return this._vertOriginY = value ?? null;
   }
 
   get ligatureCaretPositions() {}

--- a/src/glyph/Glyph.js
+++ b/src/glyph/Glyph.js
@@ -155,6 +155,31 @@ export default class Glyph {
     return this._getMetrics().advanceHeight;
   }
 
+  /**
+   * The glyph's origin Y coordinate.
+   *
+   * `undefined` if no specific value is registered for this glyph.
+   * See also `TTFFont#defaultVertOriginY` in that case.
+   * 
+   * @type {number | undefined}
+   * @see VORG https://learn.microsoft.com/en-us/typography/opentype/spec/vorg
+   */
+  get vertOriginY() {
+    if (this._vertOriginY) { return this._vertOriginY; }
+
+    const { VORG } = this._font;
+    if (!VORG) return undefined;
+    const { metrics } = VORG;
+    if (!metrics) return undefined;
+
+    const { id } = this;
+    for (const entry of metrics) {
+      if (entry.glyphIndex === id) return this._vertOriginY = entry.vertOriginY;
+    }
+
+    return undefined;
+  }
+
   get ligatureCaretPositions() {}
 
   _getName() {

--- a/src/glyph/Glyph.js
+++ b/src/glyph/Glyph.js
@@ -168,20 +168,9 @@ export default class Glyph {
     let value = this._vertOriginY;
     if (value !== undefined) return value;
 
-    const { VORG } = this._font;
-    if (VORG != null) {
-      const { metrics } = VORG;
-      if (metrics != null) {
-        const { id } = this;
-        for (const entry of metrics) {
-          if (entry.glyphIndex === id) {
-            value = entry.vertOriginY;
-            break;
-          }
-        }
-      }
-    }
-      
+    const map = this._font.getVertOriginYMap();
+    if (map != null) value = map.get(this.id);
+
     return this._vertOriginY = value ?? null;
   }
 

--- a/test/glyphs.js
+++ b/test/glyphs.js
@@ -5,6 +5,7 @@ describe('glyphs', function () {
   describe('truetype glyphs', function () {
     let font = fontkit.openSync(new URL('data/OpenSans/OpenSans-Regular.ttf', import.meta.url));
     let mada = fontkit.openSync(new URL('data/Mada/Mada-VF.ttf', import.meta.url));
+    let fontCJK = fontkit.openSync(new URL('data/NotoSansCJK/NotoSansCJKkr-Regular.otf', import.meta.url));
 
     it('should get a TTFGlyph', function () {
       let glyph = font.getGlyph(39); // D
@@ -85,6 +86,11 @@ describe('glyphs', function () {
     it('should get the glyph name', function () {
       let glyph = font.getGlyph(171);
       return assert.equal(glyph.name, 'eacute');
+    });
+
+    it('should get the vertical origin Y if a specific value exists', function () {
+      assert.equal(fontCJK.getGlyph(34).vertOriginY, undefined); // glyph 'A'
+      assert.equal(fontCJK.getGlyph(730).vertOriginY, 867); // glyph '‰', first glyph in VORG.metrics
     });
   });
 

--- a/test/glyphs.js
+++ b/test/glyphs.js
@@ -89,8 +89,8 @@ describe('glyphs', function () {
     });
 
     it('should get the vertical origin Y if a specific value exists', function () {
-      assert.equal(fontCJK.getGlyph(34).vertOriginY, undefined); // glyph 'A'
-      assert.equal(fontCJK.getGlyph(730).vertOriginY, 867); // glyph '‰', first glyph in VORG.metrics
+      assert.strictEqual(fontCJK.getGlyph(34).vertOriginY, null); // glyph 'A'
+      assert.strictEqual(fontCJK.getGlyph(730).vertOriginY, 867); // glyph '‰', first glyph in VORG.metrics
     });
   });
 

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -3,6 +3,7 @@ import assert from 'assert';
 
 describe('metadata', function () {
   let font = fontkit.openSync(new URL('data/NotoSans/NotoSans.ttc', import.meta.url), 'NotoSans');
+  let fontCJK = fontkit.openSync(new URL('data/NotoSansCJK/NotoSansCJKkr-Regular.otf', import.meta.url));
 
   it('has metadata properties', function () {
     assert.equal(font.fullName, 'Noto Sans');
@@ -28,6 +29,9 @@ describe('metadata', function () {
     assert.equal(font.bbox.minY, -600);
     assert.equal(font.bbox.maxX, 2952);
     assert.equal(font.bbox.maxY, 2189);
+
+    assert.equal(font.defaultVertOriginY, undefined);
+    assert.equal(fontCJK.defaultVertOriginY, 880);
   });
 
   it('exposes tables directly', function () {

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -30,8 +30,8 @@ describe('metadata', function () {
     assert.equal(font.bbox.maxX, 2952);
     assert.equal(font.bbox.maxY, 2189);
 
-    assert.equal(font.defaultVertOriginY, undefined);
-    assert.equal(fontCJK.defaultVertOriginY, 880);
+    assert.strictEqual(font.defaultVertOriginY, null);
+    assert.strictEqual(fontCJK.defaultVertOriginY, 880);
   });
 
   it('exposes tables directly', function () {

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -41,4 +41,22 @@ describe('metadata', function () {
       assert.equal(typeof font[table], 'object');
     }
   });
+
+  it("exposes vertOriginYMetrics in VORG table", function () {
+    assert.strictEqual(font.getVertOriginYMap(), null);
+
+    const vertOriginYMap = fontCJK.getVertOriginYMap();
+    const sampleEntries = [
+      // first three entries in VORG metrics
+      { glyphId: 730, expectedVertOriginY: 867 },
+      { glyphId: 746, expectedVertOriginY: 868 },
+      { glyphId: 747, expectedVertOriginY: 875 },
+    ];
+    for (const entry of sampleEntries) {
+      assert.strictEqual(
+        vertOriginYMap.get(entry.glyphId),
+        entry.expectedVertOriginY
+      );
+    }
+  });
 });


### PR DESCRIPTION
縦書きテキストにおけるグリフごとのY座標を特定するための下記プロパティーを追加:
    - `TTFFont#defaultVertOriginY`
    - `TTFFont#getVertOriginYMap`
    - `Glyph#vertOriginY`

なお `TTFFont#getVertOriginYMap` は、[VORG](https://learn.microsoft.com/en-us/typography/opentype/spec/vorg) がランダムアクセスに向かない構造であるため一括で読み取って `Map` に変換する目的で追加しており、これを `Glyph#vertOriginY` の中でも利用しています。