### PR TITLE
ascent, descent 等のメトリクスの取得方法を修正

### DIFF
--- a/MODIFICATIONS.md
+++ b/MODIFICATIONS.md
@@ -6,3 +6,5 @@
     - `TTFFont#defaultVertOriginY`
     - `TTFFont#getVertOriginYMap`
     - `Glyph#vertOriginY`
+- Fix data type of `version` property in `vhea` table
+- Fix properties `ascent`, `descent` and `lineGap` in `TTFFont` class so that they refer to `OS/2` table when `USE_TYPO_METRICS` flag is ON

--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -166,7 +166,12 @@ export default class TTFFont {
    * @type {number}
    */
   get ascent() {
-    return this.hhea.ascent;
+    const os2 = this['OS/2'];
+    if (os2?.fsSelection?.useTypoMetrics) {
+      return os2.typoAscender;
+    } else {
+      return this.hhea.ascent;
+    }
   }
 
   /**
@@ -174,7 +179,12 @@ export default class TTFFont {
    * @type {number}
    */
   get descent() {
-    return this.hhea.descent;
+    const os2 = this['OS/2'];
+    if (os2?.fsSelection?.useTypoMetrics) {
+      return os2.typoDescender;
+    } else {
+      return this.hhea.descent;
+    }
   }
 
   /**
@@ -182,7 +192,12 @@ export default class TTFFont {
    * @type {number}
    */
   get lineGap() {
-    return this.hhea.lineGap;
+    const os2 = this['OS/2'];
+    if (os2?.fsSelection?.useTypoMetrics) {
+      return os2.typoLineGap;
+    } else {
+      return this.hhea.lineGap;
+    }
   }
 
   /**

--- a/src/tables/vhea.js
+++ b/src/tables/vhea.js
@@ -2,7 +2,7 @@ import * as r from 'restructure';
 
 // Vertical Header Table
 export default new r.Struct({
-  version:                r.uint16,  // Version number of the Vertical Header Table
+  version:                r.uint32,  // Version number of the Vertical Header Table
   ascent:                 r.int16,   // The vertical typographic ascender for this font
   descent:                r.int16,   // The vertical typographic descender for this font
   lineGap:                r.int16,   // The vertical typographic line gap for this font

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -59,4 +59,35 @@ describe('metadata', function () {
       );
     }
   });
+
+  describe("ascent, descent and lineGap", function () {
+    const font = fontkit.openSync(
+      new URL("data/NotoSans/NotoSans.ttc", import.meta.url),
+      "NotoSans"
+    );
+    const hhea = font.hhea;
+    const os2 = font["OS/2"];
+
+    // temporary values for testing
+    hhea.ascent = 111;
+    hhea.descent = 222;
+    hhea.lineGap = 333;
+    os2.typoAscender = 777;
+    os2.typoDescender = 888;
+    os2.typoLineGap = 999;
+
+    it("expose values from OS/2 table if the USE_TYPO_METRICS flag is ON", function () {
+      os2.fsSelection.useTypoMetrics = true;
+      assert.strictEqual(font.ascent, 777);
+      assert.strictEqual(font.descent, 888);
+      assert.strictEqual(font.lineGap, 999);
+    });
+
+    it("expose values from hhea table if the USE_TYPO_METRICS flag is OFF", function () {
+      os2.fsSelection.useTypoMetrics = false;
+      assert.strictEqual(font.ascent, 111);
+      assert.strictEqual(font.descent, 222);
+      assert.strictEqual(font.lineGap, 333);
+    });
+  });
 });

--- a/test/tables.js
+++ b/test/tables.js
@@ -1,0 +1,103 @@
+import * as fontkit from "@denkiyagi/fontkit";
+import assert from "assert";
+
+describe("tables", function () {
+  const font = fontkit.openSync(
+    new URL("data/NotoSans/NotoSans.ttc", import.meta.url),
+    "NotoSans"
+  );
+  const fontCJK = fontkit.openSync(
+    new URL("data/NotoSansCJK/NotoSansCJKkr-Regular.otf", import.meta.url)
+  );
+
+  it("should expose hhea table", function () {
+    assert.deepStrictEqual(font.hhea, {
+      version: 0x10000, // v1.0
+      ascent: 2189,
+      descent: -600,
+      lineGap: 0,
+      advanceWidthMax: 2994,
+      minLeftSideBearing: 0,
+      minRightSideBearing: -1550,
+      xMaxExtent: 0,
+      caretSlopeRise: 1,
+      caretSlopeRun: 0,
+      caretOffset: 0,
+      metricDataFormat: 0,
+      numberOfMetrics: 8707,
+    });
+  });
+
+  it("should expose vhea table", function () {
+    assert.deepStrictEqual(fontCJK.vhea, {
+      version: 0x11000, // v1.1
+      ascent: 500,
+      descent: -500,
+      lineGap: 0,
+      advanceHeightMax: 3000,
+      minTopSideBearing: -1002,
+      minBottomSideBearing: -677,
+      yMaxExtent: 2928,
+      caretSlopeRise: 0,
+      caretSlopeRun: 1,
+      caretOffset: 0,
+      metricDataFormat: 0,
+      numberOfMetrics: 65167,
+    });
+  });
+
+  it("should expose OS/2 table", function () {
+    assert.deepStrictEqual(font["OS/2"], {
+      version: 4,
+      xAvgCharWidth: 1224,
+      usWeightClass: 400,
+      usWidthClass: 5,
+      fsType: {
+        noEmbedding: false,
+        viewOnly: false,
+        editable: false,
+        noSubsetting: false,
+        bitmapOnly: false,
+      },
+      ySubscriptXSize: 1434,
+      ySubscriptYSize: 1331,
+      ySubscriptXOffset: 0,
+      ySubscriptYOffset: 287,
+      ySuperscriptXSize: 1434,
+      ySuperscriptYSize: 1331,
+      ySuperscriptXOffset: 0,
+      ySuperscriptYOffset: 977,
+      yStrikeoutSize: 102,
+      yStrikeoutPosition: 512,
+      sFamilyClass: 2050,
+      panose: [2, 11, 5, 2, 4, 5, 4, 2, 2, 4],
+      ulCharRange: [3758097151, 1073772799, 41, 0],
+      vendorID: "GOOG",
+      fsSelection: {
+        italic: false,
+        underscore: false,
+        negative: false,
+        outlined: false,
+        strikeout: false,
+        bold: false,
+        regular: true,
+        useTypoMetrics: false,
+        wws: false,
+        oblique: false,
+      },
+      usFirstCharIndex: 13,
+      usLastCharIndex: 65533,
+      typoAscender: 2189,
+      typoDescender: -600,
+      typoLineGap: 0,
+      winAscent: 2189,
+      winDescent: 600,
+      codePageRange: [536871327, 3755409408],
+      xHeight: 1098,
+      capHeight: 1462,
+      defaultChar: 0,
+      breakChar: 32,
+      maxContent: 24,
+    });
+  });
+});


### PR DESCRIPTION
- `src/tables/vhea.js`
    - 実装修正: [vhea](https://learn.microsoft.com/en-us/typography/opentype/spec/vhea) テーブルの `version` のデータ型のビット数が誤っており、それによって他のフィールド（`ascent` 等）の値もすべて狂っていたのを修正
    - テスト追加 (`tables.js`): `version` について、公式仕様通りに `0x00011000` のような値が取得できること、および他のフィールドの値も問題無さそうであることを確認
- `src/TTFFont.js`
    - 実装修正: `TTFFont` 型の `ascent`, `descent`, `lineGap` プロパティーについて、従来は [hhea](https://learn.microsoft.com/en-us/typography/opentype/spec/hhea) テーブルのみを参照していたところ、[OS/2](https://learn.microsoft.com/en-us/typography/opentype/spec/os2) テーブルも参照するよう修正
    - テスト追加 (`metadata.js`): Webブラウザーと極力同じ挙動を再現（ただし相違点として、[usWinAscent](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#uswinascent) のようなWindows環境専用フィールドは使わないこととした）