### PR TITLE
APIの defaultLanguage 等が正しく export できていないのを修正

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/MODIFICATIONS.md
+++ b/MODIFICATIONS.md
@@ -16,3 +16,5 @@
     - Use named parameters
     - Add parameter `shaper` to override shaping process
     - Add parameter `skipPerGlyphPositioning` to skip calculating `GlyphRun#positions`
+- Fix fields `logErrors` and `defaultLanguage` in the top-level API
+    - Change to getter functions: `isLoggingErrors()`, `getDefaultLanguage()`

--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -1,6 +1,6 @@
 import * as r from 'restructure';
 import { cache } from './decorators';
-import * as fontkit from './base';
+import { isLoggingErrors, getDefaultLanguage as getGlobalDefaultLanguage } from './base';
 import Directory from './tables/directory';
 import tables from './tables';
 import CmapProcessor from './CmapProcessor';
@@ -57,7 +57,7 @@ export default class TTFFont {
       try {
         this._tables[table.tag] = this._decodeTable(table);
       } catch (e) {
-        if (fontkit.logErrors) {
+        if (isLoggingErrors()) {
           console.error(`Error decoding table ${table.tag}`);
           console.error(e.stack);
         }
@@ -96,14 +96,14 @@ export default class TTFFont {
    * `lang` is a BCP-47 language code.
    * @return {string}
    */
-  getName(key, lang = this.defaultLanguage || fontkit.defaultLanguage) {
+  getName(key, lang = this.defaultLanguage || getGlobalDefaultLanguage()) {
     let record = this.name && this.name.records[key];
     if (record) {
       // Attempt to retrieve the entry, depending on which translation is available:
       return (
           record[lang]
           || record[this.defaultLanguage]
-          || record[fontkit.defaultLanguage]
+          || record[getGlobalDefaultLanguage()]
           || record['en']
           || record[Object.keys(record)[0]] // Seriously, ANY language would be fine
           || null

--- a/src/base.js
+++ b/src/base.js
@@ -5,7 +5,18 @@ import { DecodeStream } from 'restructure';
 
 // -----------------------------------------------------------------------------
 
-export let logErrors = false;
+let loggingErrors = false;
+
+export function isLoggingErrors() {
+  return loggingErrors;
+}
+
+/**
+ * @param {boolean} flag
+ */
+export function logErrors(flag) {
+  loggingErrors = flag;
+}
 
 // -----------------------------------------------------------------------------
 
@@ -39,7 +50,10 @@ export function create(buffer, postscriptName) {
 
 // -----------------------------------------------------------------------------
 
-export let defaultLanguage = 'en';
+let defaultLanguage = 'en';
+export function getDefaultLanguage() {
+  return defaultLanguage;
+}
 export function setDefaultLanguage(lang = 'en') {
   defaultLanguage = lang;
 }

--- a/src/base.js
+++ b/src/base.js
@@ -1,19 +1,25 @@
 // @ts-check
 
 // @ts-ignore
-import {DecodeStream} from 'restructure';
+import { DecodeStream } from 'restructure';
+
+// -----------------------------------------------------------------------------
 
 export let logErrors = false;
+
+// -----------------------------------------------------------------------------
 
 let formats = [];
 export function registerFormat(format) {
   formats.push(format);
-};
+}
+
+// -----------------------------------------------------------------------------
 
 /**
  * @param {ArrayBufferView} buffer
  * @param {string} [postscriptName]
- * @return {import("./types").Font | import("./types").FontCollection} 
+ * @return {import("./types").Font | import("./types").FontCollection}
  */
 export function create(buffer, postscriptName) {
   for (let i = 0; i < formats.length; i++) {
@@ -29,11 +35,15 @@ export function create(buffer, postscriptName) {
   }
 
   throw new Error('Unknown font format');
-};
+}
+
+// -----------------------------------------------------------------------------
 
 export let defaultLanguage = 'en';
 export function setDefaultLanguage(lang = 'en') {
   defaultLanguage = lang;
-};
+}
 
-export { default as DefaultShaper} from './opentype/shapers/DefaultShaper';
+// -----------------------------------------------------------------------------
+
+export { default as DefaultShaper } from './opentype/shapers/DefaultShaper';

--- a/src/cff/CFFCharsets.js
+++ b/src/cff/CFFCharsets.js
@@ -1,4 +1,4 @@
-export let ISOAdobeCharset = [
+export const ISOAdobeCharset = [
   '.notdef', 'space', 'exclam', 'quotedbl', 'numbersign', 'dollar',
   'percent', 'ampersand', 'quoteright', 'parenleft', 'parenright',
   'asterisk', 'plus', 'comma', 'hyphen', 'period', 'slash', 'zero',
@@ -35,7 +35,7 @@ export let ISOAdobeCharset = [
   'ugrave', 'yacute', 'ydieresis', 'zcaron'
 ];
 
-export let ExpertCharset = [
+export const ExpertCharset = [
   '.notdef', 'space', 'exclamsmall', 'Hungarumlautsmall', 'dollaroldstyle',
   'dollarsuperior', 'ampersandsmall', 'Acutesmall', 'parenleftsuperior',
   'parenrightsuperior', 'twodotenleader', 'onedotenleader', 'comma',
@@ -75,7 +75,7 @@ export let ExpertCharset = [
   'Ydieresissmall'
 ];
 
-export let ExpertSubsetCharset = [
+export const ExpertSubsetCharset = [
   '.notdef', 'space', 'dollaroldstyle', 'dollarsuperior',
   'parenleftsuperior', 'parenrightsuperior', 'twodotenleader',
   'onedotenleader', 'comma', 'hyphen', 'period', 'fraction',

--- a/src/cff/CFFEncodings.js
+++ b/src/cff/CFFEncodings.js
@@ -1,4 +1,4 @@
-export let StandardEncoding = [
+export const StandardEncoding = [
   '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
   '', '', '', '', 'space', 'exclam', 'quotedbl', 'numbersign', 'dollar', 'percent', 'ampersand', 'quoteright',
   'parenleft', 'parenright', 'asterisk', 'plus', 'comma', 'hyphen', 'period', 'slash', 'zero', 'one', 'two',
@@ -18,7 +18,7 @@ export let StandardEncoding = [
   'lslash', 'oslash', 'oe', 'germandbls'
 ];
 
-export let ExpertEncoding = [
+export const ExpertEncoding = [
   '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
   '', '', '', '', 'space', 'exclamsmall', 'Hungarumlautsmall', '', 'dollaroldstyle', 'dollarsuperior',
   'ampersandsmall', 'Acutesmall', 'parenleftsuperior', 'parenrightsuperior', 'twodotenleader', 'onedotenleader',

--- a/src/tables/EBDT.js
+++ b/src/tables/EBDT.js
@@ -1,6 +1,6 @@
 import * as r from 'restructure';
 
-export let BigMetrics = new r.Struct({
+export const BigMetrics = new r.Struct({
   height: r.uint8,
   width: r.uint8,
   horiBearingX: r.int8,
@@ -11,7 +11,7 @@ export let BigMetrics = new r.Struct({
   vertAdvance: r.uint8
 });
 
-export let SmallMetrics = new r.Struct({
+export const SmallMetrics = new r.Struct({
   height: r.uint8,
   width: r.uint8,
   bearingX: r.int8,
@@ -29,7 +29,7 @@ class ByteAligned {}
 
 class BitAligned {}
 
-export let glyph = new r.VersionedStruct('version', {
+export const glyph = new r.VersionedStruct('version', {
   1: {
     metrics: SmallMetrics,
     data: ByteAligned

--- a/src/tables/aat.js
+++ b/src/tables/aat.js
@@ -35,7 +35,7 @@ export class UnboundedArray extends r.Array {
   }
 }
 
-export let LookupTable = function(ValueType = r.uint16) {
+export const LookupTable = function(ValueType = r.uint16) {
   // Helper class that makes internal structures invisible to pointers
   class Shadow {
     constructor(type) {

--- a/src/tables/opentype.js
+++ b/src/tables/opentype.js
@@ -27,7 +27,7 @@ let ScriptRecord = new r.Struct({
   script: new r.Pointer(r.uint16, Script, { type: 'parent' })
 });
 
-export let ScriptList = new r.Array(ScriptRecord, r.uint16);
+export const ScriptList = new r.Array(ScriptRecord, r.uint16);
 
 //#######################
 // Features and Lookups #
@@ -38,7 +38,7 @@ let FeatureParams = new r.Struct({
   nameID:     r.uint16, //OT spec: UI Name ID or uiLabelNameId
 });
 
-export let Feature = new r.Struct({
+export const Feature = new r.Struct({
   featureParams:      new r.Pointer(r.uint16, FeatureParams),
   lookupCount:        r.uint16,
   lookupListIndexes:  new r.Array(r.uint16, 'lookupCount')
@@ -49,7 +49,7 @@ let FeatureRecord = new r.Struct({
   feature:  new r.Pointer(r.uint16, Feature, { type: 'parent' })
 });
 
-export let FeatureList = new r.Array(FeatureRecord, r.uint16);
+export const FeatureList = new r.Array(FeatureRecord, r.uint16);
 
 let LookupFlags = new r.Struct({
   markAttachmentType: r.uint8,
@@ -81,7 +81,7 @@ let RangeRecord = new r.Struct({
   startCoverageIndex: r.uint16
 });
 
-export let Coverage = new r.VersionedStruct(r.uint16, {
+export const Coverage = new r.VersionedStruct(r.uint16, {
   1: {
     glyphCount:   r.uint16,
     glyphs:       new r.Array(r.uint16, 'glyphCount')
@@ -102,7 +102,7 @@ let ClassRangeRecord = new r.Struct({
   class:  r.uint16
 });
 
-export let ClassDef = new r.VersionedStruct(r.uint16, {
+export const ClassDef = new r.VersionedStruct(r.uint16, {
   1: { // Class array
     startGlyph:       r.uint16,
     glyphCount:       r.uint16,
@@ -118,7 +118,7 @@ export let ClassDef = new r.VersionedStruct(r.uint16, {
 // Device Table #
 //###############
 
-export let Device = new r.Struct({
+export const Device = new r.Struct({
   a: r.uint16, // startSize for hinting Device, outerIndex for VariationIndex
   b: r.uint16, // endSize for Device, innerIndex for VariationIndex
   deltaFormat: r.uint16
@@ -151,7 +151,7 @@ let ClassRule = new r.Struct({
 
 let ClassSet = new r.Array(new r.Pointer(r.uint16, ClassRule), r.uint16);
 
-export let Context = new r.VersionedStruct(r.uint16, {
+export const Context = new r.VersionedStruct(r.uint16, {
   1: { // Simple context
     coverage:      new r.Pointer(r.uint16, Coverage),
     ruleSetCount:  r.uint16,
@@ -188,7 +188,7 @@ let ChainRule = new r.Struct({
 
 let ChainRuleSet = new r.Array(new r.Pointer(r.uint16, ChainRule), r.uint16);
 
-export let ChainingContext = new r.VersionedStruct(r.uint16, {
+export const ChainingContext = new r.VersionedStruct(r.uint16, {
   1: { // Simple context glyph substitution
     coverage:           new r.Pointer(r.uint16, Coverage),
     chainCount:         r.uint16,

--- a/src/tables/variations.js
+++ b/src/tables/variations.js
@@ -32,7 +32,7 @@ let ItemVariationData = new r.Struct({
   deltaSets: new r.Array(DeltaSet, 'itemCount')
 });
 
-export let ItemVariationStore = new r.Struct({
+export const ItemVariationStore = new r.Struct({
   format: r.uint16,
   variationRegionList: new r.Pointer(r.uint32, VariationRegionList),
   variationDataCount: r.uint16,
@@ -73,7 +73,7 @@ let FeatureVariationRecord = new r.Struct({
   featureTableSubstitution: new r.Pointer(r.uint32, FeatureTableSubstitution, {type: 'parent'})
 });
 
-export let FeatureVariations = new r.Struct({
+export const FeatureVariations = new r.Struct({
   majorVersion: r.uint16,
   minorVersion: r.uint16,
   featureVariationRecordCount: r.uint32,

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -23,7 +23,7 @@ describe('i18n', function () {
 
     it('can set global default language to "ar"', function () {
       fontkit.setDefaultLanguage('ar');
-      assert.equal(fontkit.defaultLanguage, 'ar');
+      assert.equal(fontkit.getDefaultLanguage(), 'ar');
     });
 
     it('font now has "ar" metadata properties', function () {
@@ -37,7 +37,7 @@ describe('i18n', function () {
 
     it('can reset default language back to "en"', function () {
       fontkit.setDefaultLanguage();
-      assert.equal(fontkit.defaultLanguage, "en");
+      assert.equal(fontkit.getDefaultLanguage(), "en");
     });
   });
 


### PR DESCRIPTION
API (`src/base.js`) の `logErrors` および `defaultLanguage` について、モジュール外からは常に初期値しか取得できなかったのを修正

- 背景
    - 従来の `export let value` のように変数を export すると、import 側では初期値だけが取得され、その後 export 側の値が変更されても import 側には反映されない
- 対応
    - 変数ではなく getter 関数を export するように修正
    - 他のいくつかのモジュールにて、変更が発生しないタイプの変数が `export let` になっていたのを `export const` に修正