### PR TITLE
GlyphRun#features が意図せずnullになることがあるのを修正

### DIFF
--- a/src/layout/GlyphRun.js
+++ b/src/layout/GlyphRun.js
@@ -57,12 +57,14 @@ export default class GlyphRun {
     this.features = {};
 
     // Convert features to an object
-    if (Array.isArray(features)) {
-      for (let tag of features) {
-        this.features[tag] = true;
+    if (features != null) {
+      if (Array.isArray(features)) {
+        for (let tag of features) {
+          this.features[tag] = true;
+        }
+      } else if (typeof features === 'object') {
+        this.features = features;
       }
-    } else if (typeof features === 'object') {
-      this.features = features;
     }
   }
 

--- a/src/layout/GlyphRun.js
+++ b/src/layout/GlyphRun.js
@@ -57,7 +57,7 @@ export default class GlyphRun {
     this.features = {};
 
     // Convert features to an object
-    if (features != null) {
+    if (features) {
       if (Array.isArray(features)) {
         for (let tag of features) {
           this.features[tag] = true;


### PR DESCRIPTION
`new()` の引数 `features` が null だと `GlyphRun#features` にも null が代入されてしまい、後続処理で `Cannot set properties of null` エラーが出る状態だったため、nullチェックを追加