### PR TITLE
Improve UVS lookup performance

### DIFF
--- a/MODIFICATIONS.md
+++ b/MODIFICATIONS.md
@@ -1,5 +1,9 @@
 # Modifications
 
+## [2.0.4-mod.2025.2]
+
+- Improve performance of `CmapProcessor#lookupNonDefaultUVS` by caching variation selector records from `cmap` format 14 subtable
+
 ## [2.0.4-mod.2025.1]
 
 - Fix glyph mapping using the cmap format 14 subtable, improving support for UVS in methods like `TTFFont#glyphsForString`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@denkiyagi/fontkit",
-  "version": "2.0.4-mod.2025.1",
+  "version": "2.0.4-mod.2025.2",
   "description": "A modified version of fontkit. An advanced font engine for Node and the browser",
   "keywords": [
     "opentype",

--- a/src/CmapProcessor.js
+++ b/src/CmapProcessor.js
@@ -157,14 +157,11 @@ export default class CmapProcessor {
       return 0;
     }
 
-    let selectors = this._variationSelectorRecords;
-    let selectorIndex = binarySearch(selectors, x => variationSelector - x.varSelector);
-    
-    if (selectorIndex === -1) {
+    let sel = this._getVariationSelectorRecord(variationSelector);
+
+    if (!sel) {
       return 0;
     }
-    
-    let sel = selectors[selectorIndex];
 
     if (sel.nonDefaultUVS) {
       let nonDefaultIndex = binarySearch(sel.nonDefaultUVS, x => codepoint - x.unicodeValue);
@@ -257,6 +254,24 @@ export default class CmapProcessor {
     if (!this.uvs) return [];
 
     return this.uvs.varSelectors.toArray();
+  }
+
+  /**
+   * Get a variation selector record by its codepoint.
+   *
+   * @param {number} variationSelector 
+   * @returns The `VarSelectorRecord` instance, or `null` if not found.
+   */
+  @cache
+  _getVariationSelectorRecord(variationSelector) {
+    let selectors = this._variationSelectorRecords;
+    let selectorIndex = binarySearch(selectors, x => variationSelector - x.varSelector);
+
+    if (selectorIndex === -1) {
+      return null;
+    }
+
+    return selectors[selectorIndex];
   }
 
   @cache

--- a/src/CmapProcessor.js
+++ b/src/CmapProcessor.js
@@ -228,7 +228,7 @@ export default class CmapProcessor {
     }
 
     const variations = [];
-    for (const sel of this._variationSelectorRecords) {
+    for (const sel of this._variationSelectorRecordArray) {
       if (sel.nonDefaultUVS) {
         const { varSelector } = sel;
         for (const uvsMapping of sel.nonDefaultUVS) {
@@ -250,7 +250,7 @@ export default class CmapProcessor {
    * @see https://learn.microsoft.com/en-us/typography/opentype/spec/cmap
    */
   @cache
-  get _variationSelectorRecords() {
+  get _variationSelectorRecordArray() {
     if (!this.uvs) return [];
 
     return this.uvs.varSelectors.toArray();
@@ -264,7 +264,7 @@ export default class CmapProcessor {
    */
   @cache
   _getVariationSelectorRecord(variationSelector) {
-    let selectors = this._variationSelectorRecords;
+    let selectors = this._variationSelectorRecordArray;
     let selectorIndex = binarySearch(selectors, x => variationSelector - x.varSelector);
 
     if (selectorIndex === -1) {

--- a/src/CmapProcessor.js
+++ b/src/CmapProcessor.js
@@ -157,7 +157,7 @@ export default class CmapProcessor {
       return 0;
     }
 
-    let selectors = this.uvs.varSelectors.toArray();
+    let selectors = this._variationSelectorRecords;
     let selectorIndex = binarySearch(selectors, x => variationSelector - x.varSelector);
     
     if (selectorIndex === -1) {
@@ -226,13 +226,12 @@ export default class CmapProcessor {
    */
   @cache
   getNonDefaultUVSSet() {
-    const uvs = this.uvs;
-    if (!uvs) {
+    if (!this.uvs) {
       return [];
     }
 
     const variations = [];
-    for (const sel of uvs.varSelectors.toArray()) {
+    for (const sel of this._variationSelectorRecords) {
       if (sel.nonDefaultUVS) {
         const { varSelector } = sel;
         for (const uvsMapping of sel.nonDefaultUVS) {
@@ -246,6 +245,18 @@ export default class CmapProcessor {
     }
 
     return variations;
+  }
+
+  /**
+   * Get and cache the array of the `varSelectors` records from the UVS subtable (format 14).
+   * 
+   * @see https://learn.microsoft.com/en-us/typography/opentype/spec/cmap
+   */
+  @cache
+  get _variationSelectorRecords() {
+    if (!this.uvs) return [];
+
+    return this.uvs.varSelectors.toArray();
   }
 
   @cache


### PR DESCRIPTION
`CmapProcessor` で `lookup()` するたびに、variation selector record （参照: [OpenType - CMAP](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap) の "Format 14"）の配列生成および二分検索が発生していたため、下記をそれぞれキャッシュすることで改善：
- 新規プロパティー `_variationSelectorRecordArray` : variation selector record の全体の配列
- 新規メソッド `_getVariationSelectorRecord` : 特定の異体字セレクタから variation selector record へのマッピング