### PR TITLE
v2.0.4-mod.2025.5: native ESM に対応した型定義を提供

### DIFF
--- a/MODIFICATIONS.md
+++ b/MODIFICATIONS.md
@@ -1,6 +1,6 @@
 # Modifications
 
-## [Unreleased]
+## [2.0.4-mod.2025.5]
 
 - Add `.js` extensions to all relative imports in sources so generated `*.d.ts` are resolvable in native ESM environments
 

--- a/MODIFICATIONS.md
+++ b/MODIFICATIONS.md
@@ -1,5 +1,10 @@
 # Modifications
 
+## [Unreleased]
+
+- Add `.js` extensions to all relative imports in sources so generated `*.d.ts` are resolvable in native ESM environments
+
+
 ## [2.0.4-mod.2025.4]
 
 - Fix type declaration: Fix return type of `Subset#encode` to be `Uint8Array`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@denkiyagi/fontkit",
-  "version": "2.0.4-mod.2025.4",
+  "version": "2.0.4-mod.2025.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@denkiyagi/fontkit",
-      "version": "2.0.4-mod.2025.4",
+      "version": "2.0.4-mod.2025.5",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@denkiyagi/fontkit",
-  "version": "2.0.4-mod.2025.4",
+  "version": "2.0.4-mod.2025.5",
   "description": "A modified version of fontkit. An advanced font engine for Node and the browser",
   "keywords": [
     "opentype",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
   "files": [
     "src",
     "dist",
-    "types"
+    "types",
+    "MODIFICATIONS.md"
   ],
   "author": "DenkiYagi Inc. (modified version author), Devon Govett <devongovett@gmail.com> (orignal version author)",
   "license": "MIT",

--- a/src/CmapProcessor.js
+++ b/src/CmapProcessor.js
@@ -1,7 +1,7 @@
-import { binarySearch, range } from './utils/arrays';
-import { encodingExists, getEncoding, getEncodingMapping } from './encodings';
-import { cache } from './decorators';
-import { AssertionError, InvalidFontDataError, UnsupportedFontDataError } from './errors';
+import { binarySearch, range } from './utils/arrays.js';
+import { encodingExists, getEncoding, getEncodingMapping } from './encodings.js';
+import { cache } from './decorators.js';
+import { AssertionError, InvalidFontDataError, UnsupportedFontDataError } from './errors.js';
 
 export default class CmapProcessor {
   constructor(cmapTable) {

--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -1,20 +1,20 @@
 import * as r from 'restructure';
-import { cache } from './decorators';
-import { isLoggingWarnings, getDefaultLanguage as getGlobalDefaultLanguage } from './base';
-import Directory from './tables/directory';
-import tables from './tables/index';
-import CmapProcessor from './CmapProcessor';
-import LayoutEngine from './layout/LayoutEngine';
-import TTFGlyph from './glyph/TTFGlyph';
-import CFFGlyph from './glyph/CFFGlyph';
-import SBIXGlyph from './glyph/SBIXGlyph';
-import COLRGlyph from './glyph/COLRGlyph';
-import GlyphVariationProcessor from './glyph/GlyphVariationProcessor';
-import TTFSubset from './subset/TTFSubset';
-import CFFSubset from './subset/CFFSubset';
-import BBox from './glyph/BBox';
-import { asciiDecoder } from './utils/decode';
-import { InvalidCallerInputError } from './errors';
+import { cache } from './decorators.js';
+import { isLoggingWarnings, getDefaultLanguage as getGlobalDefaultLanguage } from './base.js';
+import Directory from './tables/directory.js';
+import tables from './tables/index.js';
+import CmapProcessor from './CmapProcessor.js';
+import LayoutEngine from './layout/LayoutEngine.js';
+import TTFGlyph from './glyph/TTFGlyph.js';
+import CFFGlyph from './glyph/CFFGlyph.js';
+import SBIXGlyph from './glyph/SBIXGlyph.js';
+import COLRGlyph from './glyph/COLRGlyph.js';
+import GlyphVariationProcessor from './glyph/GlyphVariationProcessor.js';
+import TTFSubset from './subset/TTFSubset.js';
+import CFFSubset from './subset/CFFSubset.js';
+import BBox from './glyph/BBox.js';
+import { asciiDecoder } from './utils/decode.js';
+import { InvalidCallerInputError } from './errors.js';
 
 /**
  * This is the base class for all SFNT-based font formats in fontkit.
@@ -346,7 +346,7 @@ export default class TTFFont {
    * Does not perform any advanced substitutions (there is no context to do so).
    *
    * @param {number} codePoint
-   * @return {import('./glyph/Glyph').default}
+   * @return {import('./glyph/Glyph.js').default}
    */
   glyphForCodePoint(codePoint) {
     return this.getGlyph(this._cmapProcessor.lookup(codePoint), [codePoint]);
@@ -359,7 +359,7 @@ export default class TTFFont {
    * provides a much more advanced mapping supporting AAT and OpenType shaping.
    *
    * @param {string} string
-   * @return {import('./glyph/Glyph').default[]}
+   * @return {import('./glyph/Glyph.js').default[]}
    */
   glyphsForString(string) {
     let glyphs = [];
@@ -414,8 +414,8 @@ export default class TTFFont {
    *
    * @param {string} string
    * @param {string[] | Record<string, boolean>} [userFeatures]
-   * @param {import('./types').LayoutAdvancedParams} [advancedParams]
-   * @return {import('./layout/GlyphRun').default}
+   * @param {import('./types.js').LayoutAdvancedParams} [advancedParams]
+   * @return {import('./layout/GlyphRun.js').default}
    */
   layout(string, userFeatures, advancedParams) {
     return this._layoutEngine.layout(string, userFeatures, advancedParams);
@@ -469,7 +469,7 @@ export default class TTFFont {
    *
    * @param {number} glyph
    * @param {number[]} characters
-   * @return {import('./glyph/Glyph').default}
+   * @return {import('./glyph/Glyph.js').default}
    */
   getGlyph(glyph, characters = []) {
     if (!this._glyphs[glyph]) {

--- a/src/TrueTypeCollection.js
+++ b/src/TrueTypeCollection.js
@@ -1,7 +1,7 @@
 import * as r from 'restructure';
-import TTFFont from './TTFFont';
-import { asciiDecoder } from './utils/decode';
-import { AssertionError } from './errors';
+import TTFFont from './TTFFont.js';
+import { asciiDecoder } from './utils/decode.js';
+import { AssertionError } from './errors.js';
 
 let TTCHeader = new r.VersionedStruct(r.uint32, {
   0x00010000: {

--- a/src/aat/AATLayoutEngine.js
+++ b/src/aat/AATLayoutEngine.js
@@ -1,6 +1,6 @@
-import * as AATFeatureMap from './AATFeatureMap';
-import * as Script from '../layout/Script';
-import AATMorxProcessor from './AATMorxProcessor';
+import * as AATFeatureMap from './AATFeatureMap.js';
+import * as Script from '../layout/Script.js';
+import AATMorxProcessor from './AATMorxProcessor.js';
 
 export default class AATLayoutEngine {
   constructor(font) {

--- a/src/aat/AATLookupTable.js
+++ b/src/aat/AATLookupTable.js
@@ -1,6 +1,6 @@
-import {cache} from '../decorators';
-import {range} from '../utils/arrays';
-import { InvalidFontDataError } from '../errors';
+import {cache} from '../decorators.js';
+import {range} from '../utils/arrays.js';
+import { InvalidFontDataError } from '../errors.js';
 
 export default class AATLookupTable {
   constructor(table) {

--- a/src/aat/AATMorxProcessor.js
+++ b/src/aat/AATMorxProcessor.js
@@ -1,7 +1,7 @@
-import AATStateMachine from './AATStateMachine';
-import AATLookupTable from './AATLookupTable';
-import {cache} from '../decorators';
-import { InvalidFontDataError, UnsupportedFontDataError } from '../errors';
+import AATStateMachine from './AATStateMachine.js';
+import AATLookupTable from './AATLookupTable.js';
+import {cache} from '../decorators.js';
+import { InvalidFontDataError, UnsupportedFontDataError } from '../errors.js';
 
 // indic replacement flags
 const MARK_FIRST = 0x8000;

--- a/src/aat/AATStateMachine.js
+++ b/src/aat/AATStateMachine.js
@@ -1,4 +1,4 @@
-import AATLookupTable from './AATLookupTable';
+import AATLookupTable from './AATLookupTable.js';
 
 const START_OF_TEXT_STATE = 0;
 const START_OF_LINE_STATE = 1;

--- a/src/base.js
+++ b/src/base.js
@@ -2,7 +2,7 @@
 
 // @ts-ignore
 import { DecodeStream } from 'restructure';
-import { UnsupportedFontFileFormatError } from './errors';
+import { UnsupportedFontFileFormatError } from './errors.js';
 
 // -----------------------------------------------------------------------------
 
@@ -63,4 +63,4 @@ export function setDefaultLanguage(lang = 'en') {
 
 // -----------------------------------------------------------------------------
 
-export { default as DefaultShaper } from './opentype/shapers/DefaultShaper';
+export { default as DefaultShaper } from './opentype/shapers/DefaultShaper.js';

--- a/src/cff/CFFDict.js
+++ b/src/cff/CFFDict.js
@@ -1,7 +1,7 @@
-import CFFOperand from './CFFOperand';
+import CFFOperand from './CFFOperand.js';
 import { PropertyDescriptor } from 'restructure';
-import { equalArray } from '../utils/deep-equal';
-import { InvalidFontDataError } from '../errors';
+import { equalArray } from '../utils/deep-equal.js';
+import { InvalidFontDataError } from '../errors.js';
 
 export default class CFFDict {
   constructor(ops = []) {

--- a/src/cff/CFFFont.js
+++ b/src/cff/CFFFont.js
@@ -1,9 +1,9 @@
 import * as r from 'restructure';
-import CFFIndex from './CFFIndex';
-import CFFTop from './CFFTop';
-import CFFPrivateDict from './CFFPrivateDict';
-import standardStrings from './CFFStandardStrings';
-import { InvalidFontDataError } from '../errors';
+import CFFIndex from './CFFIndex.js';
+import CFFTop from './CFFTop.js';
+import CFFPrivateDict from './CFFPrivateDict.js';
+import standardStrings from './CFFStandardStrings.js';
+import { InvalidFontDataError } from '../errors.js';
 
 class CFFFont {
   constructor(stream) {

--- a/src/cff/CFFIndex.js
+++ b/src/cff/CFFIndex.js
@@ -1,5 +1,5 @@
 import * as r from 'restructure';
-import { AssertionError, InvalidFontDataError } from '../errors';
+import { AssertionError, InvalidFontDataError } from '../errors.js';
 
 export default class CFFIndex {
   constructor(type) {

--- a/src/cff/CFFPrivateDict.js
+++ b/src/cff/CFFPrivateDict.js
@@ -1,6 +1,6 @@
-import CFFDict from './CFFDict';
-import CFFIndex from './CFFIndex';
-import CFFPointer from './CFFPointer';
+import CFFDict from './CFFDict.js';
+import CFFIndex from './CFFIndex.js';
+import CFFPointer from './CFFPointer.js';
 
 class CFFBlendOp {
   static decode(stream, parent, operands) {

--- a/src/cff/CFFTop.js
+++ b/src/cff/CFFTop.js
@@ -1,13 +1,13 @@
 import * as r from 'restructure';
 import { resolveLength } from 'restructure';
-import CFFDict from './CFFDict';
-import CFFIndex from './CFFIndex';
-import CFFPointer from './CFFPointer';
-import CFFPrivateDict from './CFFPrivateDict';
-import StandardStrings from './CFFStandardStrings';
-import { StandardEncoding, ExpertEncoding } from './CFFEncodings';
-import { ISOAdobeCharset, ExpertCharset, ExpertSubsetCharset } from './CFFCharsets';
-import { ItemVariationStore } from '../tables/variations';
+import CFFDict from './CFFDict.js';
+import CFFIndex from './CFFIndex.js';
+import CFFPointer from './CFFPointer.js';
+import CFFPrivateDict from './CFFPrivateDict.js';
+import StandardStrings from './CFFStandardStrings.js';
+import { StandardEncoding, ExpertEncoding } from './CFFEncodings.js';
+import { ISOAdobeCharset, ExpertCharset, ExpertSubsetCharset } from './CFFCharsets.js';
+import { ItemVariationStore } from '../tables/variations.js';
 
 // Checks if an operand is an index of a predefined value,
 // otherwise delegates to the provided type.

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,3 @@
+// Workaround for Parcel module resolution issue: JS files cannot resolve TS files with `*.js` extension.
+
+export * from './errors.ts';

--- a/src/fs.js
+++ b/src/fs.js
@@ -1,4 +1,4 @@
-import { create } from './base';
+import { create } from './base.js';
 import fs from 'fs';
 
 export function openSync(filename, postscriptName) {

--- a/src/glyph/CFFGlyph.js
+++ b/src/glyph/CFFGlyph.js
@@ -1,6 +1,6 @@
-import Glyph from './Glyph';
-import Path from './Path';
-import { InvalidFontDataError } from '../errors';
+import Glyph from './Glyph.js';
+import Path from './Path.js';
+import { InvalidFontDataError } from '../errors.js';
 
 /**
  * Represents an OpenType PostScript glyph, in the Compact Font Format.

--- a/src/glyph/COLRGlyph.js
+++ b/src/glyph/COLRGlyph.js
@@ -1,5 +1,5 @@
-import Glyph from './Glyph';
-import BBox from './BBox';
+import Glyph from './Glyph.js';
+import BBox from './BBox.js';
 
 class COLRLayer {
   constructor(glyph, color) {

--- a/src/glyph/Glyph.js
+++ b/src/glyph/Glyph.js
@@ -1,7 +1,7 @@
-import { cache } from '../decorators';
-import Path from './Path';
+import { cache } from '../decorators.js';
+import Path from './Path.js';
 import { isMark } from 'unicode-properties';
-import StandardNames from './StandardNames';
+import StandardNames from './StandardNames.js';
 
 /**
  * Glyph objects represent a glyph in the font. They have various properties for accessing metrics and
@@ -99,7 +99,7 @@ export default class Glyph {
    * See [here](http://www.freetype.org/freetype2/docs/glyphs/glyphs-6.html#section-2)
    * for a more detailed description.
    *
-   * @type {import('./BBox').default}
+   * @type {import('./BBox.js').default}
    */
   @cache
   get cbox() {
@@ -109,7 +109,7 @@ export default class Glyph {
   /**
    * The glyph’s bounding box, i.e. the rectangle that encloses the
    * glyph outline as tightly as possible.
-   * @type {import('./BBox').default}
+   * @type {import('./BBox.js').default}
    */
   @cache
   get bbox() {

--- a/src/glyph/GlyphVariationProcessor.js
+++ b/src/glyph/GlyphVariationProcessor.js
@@ -1,4 +1,4 @@
-import { InvalidFontDataError } from '../errors';
+import { InvalidFontDataError } from '../errors.js';
 
 const TUPLES_SHARE_POINT_NUMBERS = 0x8000;
 const TUPLE_COUNT_MASK           = 0x0fff;

--- a/src/glyph/Path.js
+++ b/src/glyph/Path.js
@@ -1,4 +1,4 @@
-import BBox from './BBox';
+import BBox from './BBox.js';
 
 const SVG_COMMANDS = {
   moveTo: 'M',

--- a/src/glyph/SBIXGlyph.js
+++ b/src/glyph/SBIXGlyph.js
@@ -1,4 +1,4 @@
-import TTFGlyph from './TTFGlyph';
+import TTFGlyph from './TTFGlyph.js';
 import * as r from 'restructure';
 
 let SBIXImage = new r.Struct({

--- a/src/glyph/TTFGlyph.js
+++ b/src/glyph/TTFGlyph.js
@@ -1,8 +1,8 @@
-import Glyph from './Glyph';
-import Path from './Path';
-import BBox from './BBox';
+import Glyph from './Glyph.js';
+import Path from './Path.js';
+import BBox from './BBox.js';
 import * as r from 'restructure';
-import { InvalidFontDataError } from '../errors';
+import { InvalidFontDataError } from '../errors.js';
 
 // The header for both simple and composite glyphs
 let GlyfHeader = new r.Struct({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,28 +1,28 @@
-import { registerFormat } from './base';
-import TTFFont from './TTFFont';
-import TrueTypeCollection from './TrueTypeCollection';
+import { registerFormat } from './base.js';
+import TTFFont from './TTFFont.js';
+import TrueTypeCollection from './TrueTypeCollection.js';
 
 // Register font formats
 registerFormat(TTFFont);
 registerFormat(TrueTypeCollection);
 
-export * from './base';
-export { DefaultShaper } from './base'; // Explicit export for preventing tree-shaking
+export * from './base.js';
+export { DefaultShaper } from './base.js'; // Explicit export for preventing tree-shaking
 
-export * from './errors';
+export * from './errors.js';
 
-export type { default as TTFFont } from './TTFFont';
-export type { default as TrueTypeCollection } from './TrueTypeCollection';
-export type { default as Glyph } from './glyph/Glyph';
-export type { default as BBox } from './glyph/BBox';
-export type { default as Path } from './glyph/Path';
-export type { default as GlyphPosition } from './layout/GlyphPosition';
-export type { default as GlyphRun } from './layout/GlyphRun';
-export type { default as Subset } from './subset/Subset';
+export type { default as TTFFont } from './TTFFont.js';
+export type { default as TrueTypeCollection } from './TrueTypeCollection.js';
+export type { default as Glyph } from './glyph/Glyph.js';
+export type { default as BBox } from './glyph/BBox.js';
+export type { default as Path } from './glyph/Path.js';
+export type { default as GlyphPosition } from './layout/GlyphPosition.js';
+export type { default as GlyphRun } from './layout/GlyphRun.js';
+export type { default as Subset } from './subset/Subset.js';
 
 export type {
   GlyphInfo,
   ShapingPlan,
   LayoutAdvancedParams,
   Shaper,
-} from './types';
+} from './types.js';

--- a/src/layout/GlyphRun.js
+++ b/src/layout/GlyphRun.js
@@ -1,7 +1,7 @@
 // @ts-check
 
-import BBox from '../glyph/BBox';
-import * as Script from '../layout/Script';
+import BBox from '../glyph/BBox.js';
+import * as Script from '../layout/Script.js';
 
 /**
  * Represents a run of Glyph and GlyphPosition objects.
@@ -9,7 +9,7 @@ import * as Script from '../layout/Script';
  */
 export default class GlyphRun {
   /**
-   * @param {import('../glyph/Glyph').default[]} glyphs
+   * @param {import('../glyph/Glyph.js').default[]} glyphs
    * @param {string[] | Record<string, boolean> | null | undefined} features
    * @param {string} [script]
    * @param {string} [language]
@@ -18,14 +18,14 @@ export default class GlyphRun {
   constructor(glyphs, features, script, language, direction) {
     /**
      * An array of Glyph objects in the run
-     * @type {import('../glyph/Glyph').default[]}
+     * @type {import('../glyph/Glyph.js').default[]}
      */
     this.glyphs = glyphs;
 
     /**
      * An array of GlyphPosition objects for each glyph in the run.
      * Initially `null` and may be assigned in the glyph positioning process.
-     * @type {(import('./GlyphPosition').default[] | null)}
+     * @type {(import('./GlyphPosition.js').default[] | null)}
      */
     this.positions = null;
 

--- a/src/layout/KernProcessor.js
+++ b/src/layout/KernProcessor.js
@@ -1,11 +1,11 @@
 // @ts-check
 
-import { UnsupportedFontDataError } from '../errors';
-import { binarySearch } from '../utils/arrays';
+import { UnsupportedFontDataError } from '../errors.js';
+import { binarySearch } from '../utils/arrays.js';
 
 export default class KernProcessor {
   /**
-   * @param {import('../TTFFont').default} font
+   * @param {import('../TTFFont.js').default} font
    */
   constructor(font) {
     /**
@@ -16,8 +16,8 @@ export default class KernProcessor {
   }
 
   /**
-   * @param {import('../glyph/Glyph').default[]} glyphs 
-   * @param {import('./GlyphPosition').default[]} positions 
+   * @param {import('../glyph/Glyph.js').default[]} glyphs 
+   * @param {import('./GlyphPosition.js').default[]} positions 
    */
   process(glyphs, positions) {
     for (let glyphIndex = 0; glyphIndex < glyphs.length - 1; glyphIndex++) {

--- a/src/layout/LayoutEngine.js
+++ b/src/layout/LayoutEngine.js
@@ -1,20 +1,20 @@
 // @ts-check
 
-import KernProcessor from './KernProcessor';
-import UnicodeLayoutEngine from './UnicodeLayoutEngine';
-import GlyphRun from './GlyphRun';
-import * as Script from './Script';
-import AATLayoutEngine from '../aat/AATLayoutEngine';
-import OTLayoutEngine from '../opentype/OTLayoutEngine';
-import GlyphPosition from './GlyphPosition';
+import KernProcessor from './KernProcessor.js';
+import UnicodeLayoutEngine from './UnicodeLayoutEngine.js';
+import GlyphRun from './GlyphRun.js';
+import * as Script from './Script.js';
+import AATLayoutEngine from '../aat/AATLayoutEngine.js';
+import OTLayoutEngine from '../opentype/OTLayoutEngine.js';
+import GlyphPosition from './GlyphPosition.js';
 
 export default class LayoutEngine {
   /**
-   * @param {import('../TTFFont').default} font 
+   * @param {import('../TTFFont.js').default} font 
    */
   constructor(font) {
     /**
-     * @type {import('../TTFFont').default}
+     * @type {import('../TTFFont.js').default}
      */
     // @ts-ignore
     this.font = font;
@@ -33,9 +33,9 @@ export default class LayoutEngine {
   }
 
   /**
-   * @param {string | import('../glyph/Glyph').default[]} string 
+   * @param {string | import('../glyph/Glyph.js').default[]} string 
    * @param {string[] | Record<string, boolean>} [features] 
-   * @param {import('../types').LayoutAdvancedParams} [advancedParams]
+   * @param {import('../types.js').LayoutAdvancedParams} [advancedParams]
    * @returns {GlyphRun}
    */
   layout(string, features, advancedParams = {}) {

--- a/src/layout/UnicodeLayoutEngine.js
+++ b/src/layout/UnicodeLayoutEngine.js
@@ -12,16 +12,16 @@ import { getCombiningClass } from 'unicode-properties';
  */
 export default class UnicodeLayoutEngine {
   /**
-   * @param {import('../TTFFont').default} font
+   * @param {import('../TTFFont.js').default} font
    */
   constructor(font) {
     this.font = font;
   }
 
   /**
-   * @param {import('../glyph/Glyph').default[]} glyphs
-   * @param {import('./GlyphPosition').default[]} positions
-   * @returns {import('./GlyphPosition').default[]}
+   * @param {import('../glyph/Glyph.js').default[]} glyphs
+   * @param {import('./GlyphPosition.js').default[]} positions
+   * @returns {import('./GlyphPosition.js').default[]}
    */
   positionGlyphs(glyphs, positions) {
     // find each base + mark cluster, and position the marks relative to the base
@@ -48,8 +48,8 @@ export default class UnicodeLayoutEngine {
   }
 
   /**
-   * @param {import('../glyph/Glyph').default[]} glyphs
-   * @param {import('./GlyphPosition').default[]} positions
+   * @param {import('../glyph/Glyph.js').default[]} glyphs
+   * @param {import('./GlyphPosition.js').default[]} positions
    * @param {number} clusterStart
    * @param {number} clusterEnd
    */

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,30 +1,30 @@
-import { registerFormat } from './base';
-import TTFFont from './TTFFont';
-import TrueTypeCollection from './TrueTypeCollection';
+import { registerFormat } from './base.js';
+import TTFFont from './TTFFont.js';
+import TrueTypeCollection from './TrueTypeCollection.js';
 
 // Register font formats
 registerFormat(TTFFont);
 registerFormat(TrueTypeCollection);
 
-export * from './base';
-export { DefaultShaper } from './base'; // Explicit export for preventing tree-shaking
+export * from './base.js';
+export { DefaultShaper } from './base.js'; // Explicit export for preventing tree-shaking
 
-export * from './errors';
+export * from './errors.js';
 
-export type { default as TTFFont } from './TTFFont';
-export type { default as TrueTypeCollection } from './TrueTypeCollection';
-export type { default as Glyph } from './glyph/Glyph';
-export type { default as BBox } from './glyph/BBox';
-export type { default as Path } from './glyph/Path';
-export type { default as GlyphPosition } from './layout/GlyphPosition';
-export type { default as GlyphRun } from './layout/GlyphRun';
-export type { default as Subset } from './subset/Subset';
+export type { default as TTFFont } from './TTFFont.js';
+export type { default as TrueTypeCollection } from './TrueTypeCollection.js';
+export type { default as Glyph } from './glyph/Glyph.js';
+export type { default as BBox } from './glyph/BBox.js';
+export type { default as Path } from './glyph/Path.js';
+export type { default as GlyphPosition } from './layout/GlyphPosition.js';
+export type { default as GlyphRun } from './layout/GlyphRun.js';
+export type { default as Subset } from './subset/Subset.js';
 
 export type {
   GlyphInfo,
   ShapingPlan,
   LayoutAdvancedParams,
   Shaper,
-} from './types';
+} from './types.js';
 
-export * from './fs';
+export * from './fs.js';

--- a/src/opentype/GPOSProcessor.js
+++ b/src/opentype/GPOSProcessor.js
@@ -1,6 +1,6 @@
-import GlyphPosition from '../layout/GlyphPosition';
-import OTProcessor from './OTProcessor';
-import { InvalidFontDataError } from '../errors';
+import GlyphPosition from '../layout/GlyphPosition.js';
+import OTProcessor from './OTProcessor.js';
+import { InvalidFontDataError } from '../errors.js';
 
 /**
  * Null object for `GlyphPosition`.
@@ -320,8 +320,8 @@ export default class GPOSProcessor extends OTProcessor {
 
   /**
    * @param {string[]} userFeatures
-   * @param {import('./GlyphInfo').default[]} glyphs
-   * @param {import('../layout/GlyphPosition').default[]} [advances]
+   * @param {import('./GlyphInfo.js').default[]} glyphs
+   * @param {import('../layout/GlyphPosition.js').default[]} [advances]
    */
   applyFeatures(userFeatures, glyphs, advances) {
     super.applyFeatures(userFeatures, glyphs, advances);

--- a/src/opentype/GSUBProcessor.js
+++ b/src/opentype/GSUBProcessor.js
@@ -1,6 +1,6 @@
-import OTProcessor from './OTProcessor';
-import GlyphInfo from './GlyphInfo';
-import { InvalidFontDataError, UnsupportedFontDataError } from '../errors';
+import OTProcessor from './OTProcessor.js';
+import GlyphInfo from './GlyphInfo.js';
+import { InvalidFontDataError, UnsupportedFontDataError } from '../errors.js';
 
 export default class GSUBProcessor extends OTProcessor {
   applyLookup(lookupType, table) {

--- a/src/opentype/GlyphInfo.js
+++ b/src/opentype/GlyphInfo.js
@@ -1,5 +1,5 @@
 import {isMark} from 'unicode-properties';
-import OTProcessor from './OTProcessor';
+import OTProcessor from './OTProcessor.js';
 
 export default class GlyphInfo {
   constructor(font, id, codePoints = [], features) {

--- a/src/opentype/OTLayoutEngine.js
+++ b/src/opentype/OTLayoutEngine.js
@@ -1,15 +1,15 @@
 // @ts-check
 
-import ShapingPlan from './ShapingPlan';
-import * as Shapers from './shapers/index';
-import GlyphInfo from './GlyphInfo';
-import GSUBProcessor from './GSUBProcessor';
-import GPOSProcessor from './GPOSProcessor';
-import { AssertionError } from '../errors';
+import ShapingPlan from './ShapingPlan.js';
+import * as Shapers from './shapers/index.js';
+import GlyphInfo from './GlyphInfo.js';
+import GSUBProcessor from './GSUBProcessor.js';
+import GPOSProcessor from './GPOSProcessor.js';
+import { AssertionError } from '../errors.js';
 
 export default class OTLayoutEngine {
   /**
-   * @param {import('../TTFFont').default} font 
+   * @param {import('../TTFFont.js').default} font 
    */
   constructor(font) {
     this.font = font;
@@ -29,8 +29,8 @@ export default class OTLayoutEngine {
   }
 
   /**
-   * @param {import('../layout/GlyphRun').default} glyphRun 
-   * @param {import('../types').Shaper} [shaper]
+   * @param {import('../layout/GlyphRun.js').default} glyphRun 
+   * @param {import('../types.js').Shaper} [shaper]
    */
   setup(glyphRun, shaper) {
     // Map glyphs to GlyphInfo objects so data can be passed between
@@ -60,7 +60,7 @@ export default class OTLayoutEngine {
   }
 
   /**
-   * @param {import('../layout/GlyphRun').default} glyphRun 
+   * @param {import('../layout/GlyphRun.js').default} glyphRun 
    */
   substitute(glyphRun) {
     if (this.glyphInfos == null || this.plan == null) {
@@ -77,7 +77,7 @@ export default class OTLayoutEngine {
   }
 
   /**
-   * @param {import('../layout/GlyphRun').default} glyphRun
+   * @param {import('../layout/GlyphRun.js').default} glyphRun
    * @returns {(Record<string, any> | null)} GPOSProcessor#features
    */
   position(glyphRun) {
@@ -115,7 +115,7 @@ export default class OTLayoutEngine {
 
   /**
    * 
-   * @param {import('../layout/GlyphPosition').default[]} positions 
+   * @param {import('../layout/GlyphPosition.js').default[]} positions 
    */
   zeroMarkAdvances(positions) {
     if (this.glyphInfos == null) {

--- a/src/opentype/OTProcessor.js
+++ b/src/opentype/OTProcessor.js
@@ -1,6 +1,6 @@
-import GlyphIterator from './GlyphIterator';
-import * as Script from '../layout/Script';
-import { AssertionError } from '../errors';
+import GlyphIterator from './GlyphIterator.js';
+import * as Script from '../layout/Script.js';
+import { AssertionError } from '../errors.js';
 
 const DEFAULT_SCRIPTS = ['DFLT', 'dflt', 'latn'];
 
@@ -30,9 +30,9 @@ export default class OTProcessor {
     this.selectScript();
 
     // current context (set by applyFeatures)
-    /** @type {import('./GlyphInfo').default[]} */
+    /** @type {import('./GlyphInfo.js').default[]} */
     this.glyphs = [];
-    /** @type {(import('../layout/GlyphPosition').default[] | undefined)} */
+    /** @type {(import('../layout/GlyphPosition.js').default[] | undefined)} */
     this.positions = undefined; // only used by GPOS
     this.ligatureID = 1;
     this.currentFeature = null;
@@ -187,8 +187,8 @@ export default class OTProcessor {
 
   /**
    * @param {string[]} userFeatures
-   * @param {import('./GlyphInfo').default[]} glyphs
-   * @param {import('../layout/GlyphPosition').default[]} [advances]
+   * @param {import('./GlyphInfo.js').default[]} glyphs
+   * @param {import('../layout/GlyphPosition.js').default[]} [advances]
    */
   applyFeatures(userFeatures, glyphs, advances) {
     let lookups = this.lookupsForFeatures(userFeatures);

--- a/src/opentype/ShapingPlan.js
+++ b/src/opentype/ShapingPlan.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { AssertionError, InvalidCallerInputError } from '../errors';
+import { AssertionError, InvalidCallerInputError } from '../errors.js';
 
 /**
  * ShapingPlans are used by the OpenType shapers to store which
@@ -13,7 +13,7 @@ import { AssertionError, InvalidCallerInputError } from '../errors';
  */
 export default class ShapingPlan {
   /**
-   * @param {import('../TTFFont').default} font 
+   * @param {import('../TTFFont.js').default} font 
    * @param {string} script 
    * @param {'ltr' | 'rtl'} direction 
    */
@@ -23,7 +23,7 @@ export default class ShapingPlan {
     this.direction = direction;
 
     /**
-     * @type {import('../types').ShapingPlanStage[]}
+     * @type {import('../types.js').ShapingPlanStage[]}
      */
     this.stages = [];
 
@@ -85,7 +85,7 @@ export default class ShapingPlan {
   /**
    * Add a new stage
    * 
-   * @param {import('../types').ShapingPlanStageFunction | string | string[] | {global?: string[], local?: string[]}} arg
+   * @param {import('../types.js').ShapingPlanStageFunction | string | string[] | {global?: string[], local?: string[]}} arg
    * @param {boolean} [global]
    */
   addStage(arg, global) {
@@ -124,7 +124,7 @@ export default class ShapingPlan {
   /**
    * Assigns the global features to the given glyphs
    * 
-   * @param {import('./GlyphInfo').default[]} glyphs
+   * @param {import('./GlyphInfo.js').default[]} glyphs
    */
   assignGlobalFeatures(glyphs) {
     for (let glyph of glyphs) {
@@ -137,9 +137,9 @@ export default class ShapingPlan {
   /**
    * Executes the planned stages using the given OTProcessor
    * 
-   * @param {import('./OTProcessor').default} processor
-   * @param {import('./GlyphInfo').default[]} glyphs
-   * @param {import('../layout/GlyphPosition').default[]} [positions]
+   * @param {import('./OTProcessor.js').default} processor
+   * @param {import('./GlyphInfo.js').default[]} glyphs
+   * @param {import('../layout/GlyphPosition.js').default[]} [positions]
    */
   process(processor, glyphs, positions) {
     for (let stage of this.stages) {

--- a/src/opentype/shapers/ArabicShaper.js
+++ b/src/opentype/shapers/ArabicShaper.js
@@ -1,7 +1,7 @@
-import DefaultShaper from './DefaultShaper';
+import DefaultShaper from './DefaultShaper.js';
 import {getCategory} from 'unicode-properties';
 import UnicodeTrie from 'unicode-trie';
-import { decodeBase64 } from '../../utils/decode';
+import { decodeBase64 } from '../../utils/decode.js';
 
 const trie = new UnicodeTrie(decodeBase64(require('fs').readFileSync(__dirname + '/data.trie', 'base64')));
 const FEATURES = ['isol', 'fina', 'fin2', 'fin3', 'medi', 'med2', 'init'];
@@ -65,7 +65,7 @@ const STATE_TABLE = [
  */
 export default class ArabicShaper extends DefaultShaper {
   /**
-   * @param {import('../ShapingPlan').default} plan
+   * @param {import('../ShapingPlan.js').default} plan
    */
   planPreprocessing(plan) {
     super.planPreprocessing(plan);
@@ -73,7 +73,7 @@ export default class ArabicShaper extends DefaultShaper {
   }
 
   /**
-   * @param {import('../ShapingPlan').default} plan
+   * @param {import('../ShapingPlan.js').default} plan
    */
   planFeatures(plan) {
     plan.add(['ccmp', 'locl']);
@@ -86,8 +86,8 @@ export default class ArabicShaper extends DefaultShaper {
   }
 
   /**
-   * @param {import('../ShapingPlan').default} plan
-   * @param {import('../GlyphInfo').default[]} glyphs
+   * @param {import('../ShapingPlan.js').default} plan
+   * @param {import('../GlyphInfo.js').default[]} glyphs
    */
   assignFeatures(plan, glyphs) {
     super.assignFeatures(plan, glyphs);

--- a/src/opentype/shapers/DefaultShaper.js
+++ b/src/opentype/shapers/DefaultShaper.js
@@ -11,8 +11,8 @@ export default class DefaultShaper {
   zeroMarkWidths = 'AFTER_GPOS';
 
   /**
-   * @param {import('../ShapingPlan').default} plan
-   * @param {import('../GlyphInfo').default[]} glyphs
+   * @param {import('../ShapingPlan.js').default} plan
+   * @param {import('../GlyphInfo.js').default[]} glyphs
    * @param {string[] | Record<string, boolean>} features
    */
   plan(plan, glyphs, features) {
@@ -29,21 +29,21 @@ export default class DefaultShaper {
   }
 
   /**
-   * @param {import('../ShapingPlan').default} plan
+   * @param {import('../ShapingPlan.js').default} plan
    */
   planPreprocessing(plan) {
     plan.add(VARIATION_FEATURES);
   }
 
   /**
-   * @param {import('../ShapingPlan').default} plan
+   * @param {import('../ShapingPlan.js').default} plan
    */
   planFeatures(plan) {
     // Do nothing by default. Let subclasses override this.
   }
 
   /**
-   * @param {import('../ShapingPlan').default} plan
+   * @param {import('../ShapingPlan.js').default} plan
    * @param {string[] | Record<string, boolean>} userFeatures
    */
   planPostprocessing(plan, userFeatures) {
@@ -52,8 +52,8 @@ export default class DefaultShaper {
   }
 
   /**
-   * @param {import('../ShapingPlan').default} plan
-   * @param {import('../GlyphInfo').default[]} glyphs
+   * @param {import('../ShapingPlan.js').default} plan
+   * @param {import('../GlyphInfo.js').default[]} glyphs
    */
   assignFeatures(plan, glyphs) {
     // Do nothing by default. Let subclasses override this.

--- a/src/opentype/shapers/HangulShaper.js
+++ b/src/opentype/shapers/HangulShaper.js
@@ -1,5 +1,5 @@
-import DefaultShaper from './DefaultShaper';
-import GlyphInfo from '../GlyphInfo';
+import DefaultShaper from './DefaultShaper.js';
+import GlyphInfo from '../GlyphInfo.js';
 
 /**
  * This is a shaper for the Hangul script, used by the Korean language.

--- a/src/opentype/shapers/IndicShaper.js
+++ b/src/opentype/shapers/IndicShaper.js
@@ -1,9 +1,9 @@
-import DefaultShaper from './DefaultShaper';
+import DefaultShaper from './DefaultShaper.js';
 import StateMachine from 'dfa';
 import UnicodeTrie from 'unicode-trie';
 import {getCategory} from 'unicode-properties';
-import * as Script from '../../layout/Script';
-import GlyphInfo from '../GlyphInfo';
+import * as Script from '../../layout/Script.js';
+import GlyphInfo from '../GlyphInfo.js';
 import indicMachine from './indic.json';
 import useData from './use.json';
 import {
@@ -13,8 +13,8 @@ import {
   JOINER_FLAGS,
   HALANT_OR_COENG_FLAGS, INDIC_CONFIGS,
   INDIC_DECOMPOSITIONS
-} from './indic-data';
-import { decodeBase64 } from '../../utils/decode';
+} from './indic-data.js';
+import { decodeBase64 } from '../../utils/decode.js';
 
 const {decompositions} = useData;
 const trie = new UnicodeTrie(decodeBase64(require('fs').readFileSync(__dirname + '/indic.trie', 'base64')));
@@ -66,8 +66,8 @@ export default class IndicShaper extends DefaultShaper {
   }
 
   /**
-   * @param {import('../ShapingPlan').default} plan
-   * @param {import('../GlyphInfo').default[]} glyphs
+   * @param {import('../ShapingPlan.js').default} plan
+   * @param {import('../GlyphInfo.js').default[]} glyphs
    */
   assignFeatures(plan, glyphs) {
     // Decompose split matras

--- a/src/opentype/shapers/UniversalShaper.js
+++ b/src/opentype/shapers/UniversalShaper.js
@@ -1,9 +1,9 @@
-import DefaultShaper from './DefaultShaper';
+import DefaultShaper from './DefaultShaper.js';
 import StateMachine from 'dfa';
 import UnicodeTrie from 'unicode-trie';
-import GlyphInfo from '../GlyphInfo';
+import GlyphInfo from '../GlyphInfo.js';
 import useData from './use.json';
-import { decodeBase64 } from '../../utils/decode';
+import { decodeBase64 } from '../../utils/decode.js';
 
 const {categories, decompositions} = useData;
 const trie = new UnicodeTrie(decodeBase64(require('fs').readFileSync(__dirname + '/use.trie', 'base64')));
@@ -47,8 +47,8 @@ export default class UniversalShaper extends DefaultShaper {
   }
 
   /**
-   * @param {import('../ShapingPlan').default} plan
-   * @param {import('../GlyphInfo').default[]} glyphs
+   * @param {import('../ShapingPlan.js').default} plan
+   * @param {import('../GlyphInfo.js').default[]} glyphs
    */
   assignFeatures(plan, glyphs) {
     // Decompose split vowels

--- a/src/opentype/shapers/index.js
+++ b/src/opentype/shapers/index.js
@@ -1,10 +1,10 @@
 // @ts-check
 
-import DefaultShaper from './DefaultShaper';
-import ArabicShaper from './ArabicShaper';
-import HangulShaper from './HangulShaper';
-import IndicShaper from './IndicShaper';
-import UniversalShaper from './UniversalShaper';
+import DefaultShaper from './DefaultShaper.js';
+import ArabicShaper from './ArabicShaper.js';
+import HangulShaper from './HangulShaper.js';
+import IndicShaper from './IndicShaper.js';
+import UniversalShaper from './UniversalShaper.js';
 
 const defaultShaper = new DefaultShaper();
 const arabicShaper = new ArabicShaper();
@@ -96,7 +96,7 @@ const SHAPERS = {
 
 /**
  * @param {string | string[]} script
- * @returns {import('../../types').Shaper}
+ * @returns {import('../../types.js').Shaper}
  */
 export function choose(script) {
   if (!Array.isArray(script)) {

--- a/src/subset/CFFSubset.js
+++ b/src/subset/CFFSubset.js
@@ -1,7 +1,7 @@
-import Subset from './Subset';
-import CFFTop from '../cff/CFFTop';
-import standardStrings from '../cff/CFFStandardStrings';
-import { AssertionError } from '../errors';
+import Subset from './Subset.js';
+import CFFTop from '../cff/CFFTop.js';
+import standardStrings from '../cff/CFFStandardStrings.js';
+import { AssertionError } from '../errors.js';
 
 export default class CFFSubset extends Subset {
   /**

--- a/src/subset/Subset.js
+++ b/src/subset/Subset.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { AssertionError } from '../errors';
+import { AssertionError } from '../errors.js';
 
 /**
  * @abstract
@@ -12,11 +12,11 @@ export default class Subset {
   type = 'UNKNOWN';
 
   /**
-   * @param {import('../TTFFont').default} font
+   * @param {import('../TTFFont.js').default} font
    */
   constructor(font) {
     /**
-     * @type {import('../TTFFont').default}
+     * @type {import('../TTFFont.js').default}
      */
     this.font = font;
 
@@ -35,7 +35,7 @@ export default class Subset {
   }
 
   /**
-   * @param {(number | import('../glyph/Glyph').default)} glyph
+   * @param {(number | import('../glyph/Glyph.js').default)} glyph
    * @returns {number}
    */
   includeGlyph(glyph) {

--- a/src/subset/TTFSubset.js
+++ b/src/subset/TTFSubset.js
@@ -1,8 +1,8 @@
-import { cloneDeep } from '../utils/clone';
-import Subset from './Subset';
-import Directory from '../tables/directory';
-import Tables from '../tables';
-import TTFGlyphEncoder from '../glyph/TTFGlyphEncoder';
+import { cloneDeep } from '../utils/clone.js';
+import Subset from './Subset.js';
+import Directory from '../tables/directory.js';
+import Tables from '../tables/index.js';
+import TTFGlyphEncoder from '../glyph/TTFGlyphEncoder.js';
 
 export default class TTFSubset extends Subset {
   /**

--- a/src/tables/BASE.js
+++ b/src/tables/BASE.js
@@ -1,6 +1,6 @@
 import * as r from 'restructure';
-import {ScriptList, FeatureList, LookupList, Coverage, ClassDef, Device} from './opentype';
-import {ItemVariationStore} from './variations';
+import {ScriptList, FeatureList, LookupList, Coverage, ClassDef, Device} from './opentype.js';
+import {ItemVariationStore} from './variations.js';
 
 let BaseCoord = new r.VersionedStruct(r.uint16, {
   1: { // Design units only

--- a/src/tables/EBLC.js
+++ b/src/tables/EBLC.js
@@ -1,5 +1,5 @@
 import * as r from 'restructure';
-import {BigMetrics} from './EBDT';
+import {BigMetrics} from './EBDT.js';
 
 let SBitLineMetrics = new r.Struct({
   ascender: r.int8,

--- a/src/tables/GDEF.js
+++ b/src/tables/GDEF.js
@@ -1,6 +1,6 @@
 import * as r from 'restructure';
-import {ScriptList, FeatureList, LookupList, Coverage, ClassDef, Device} from './opentype';
-import {ItemVariationStore} from './variations';
+import {ScriptList, FeatureList, LookupList, Coverage, ClassDef, Device} from './opentype.js';
+import {ItemVariationStore} from './variations.js';
 
 let AttachPoint = new r.Array(r.uint16, r.uint16);
 let AttachList = new r.Struct({

--- a/src/tables/GPOS.js
+++ b/src/tables/GPOS.js
@@ -1,6 +1,6 @@
 import * as r from 'restructure';
-import {ScriptList, FeatureList, LookupList, Coverage, ClassDef, Device, Context, ChainingContext} from './opentype';
-import {FeatureVariations} from './variations';
+import {ScriptList, FeatureList, LookupList, Coverage, ClassDef, Device, Context, ChainingContext} from './opentype.js';
+import {FeatureVariations} from './variations.js';
 
 let ValueFormat = new r.Bitfield(r.uint16, [
   'xPlacement', 'yPlacement',

--- a/src/tables/GSUB.js
+++ b/src/tables/GSUB.js
@@ -1,6 +1,6 @@
 import * as r from 'restructure';
-import {ScriptList, FeatureList, LookupList, Coverage, ClassDef, Device, Context, ChainingContext} from './opentype';
-import {FeatureVariations} from './variations';
+import {ScriptList, FeatureList, LookupList, Coverage, ClassDef, Device, Context, ChainingContext} from './opentype.js';
+import {FeatureVariations} from './variations.js';
 
 let Sequence = new r.Array(r.uint16, r.uint16);
 let AlternateSet = Sequence;

--- a/src/tables/HVAR.js
+++ b/src/tables/HVAR.js
@@ -1,6 +1,6 @@
 import * as r from 'restructure';
 import { resolveLength } from 'restructure';
-import { ItemVariationStore } from './variations';
+import { ItemVariationStore } from './variations.js';
 
 // TODO: add this to restructure
 class VariableSizeNumber {

--- a/src/tables/JSTF.js
+++ b/src/tables/JSTF.js
@@ -1,6 +1,6 @@
 import * as r from 'restructure';
-import { ScriptList, FeatureList, LookupList, Coverage, ClassDef, Device } from './opentype';
-import { GPOSLookup } from './GPOS';
+import { ScriptList, FeatureList, LookupList, Coverage, ClassDef, Device } from './opentype.js';
+import { GPOSLookup } from './GPOS.js';
 
 let JstfGSUBModList = new r.Array(r.uint16, r.uint16);
 

--- a/src/tables/bsln.js
+++ b/src/tables/bsln.js
@@ -1,5 +1,5 @@
 import * as r from 'restructure';
-import { LookupTable } from './aat';
+import { LookupTable } from './aat.js';
 
 let BslnSubtable = new r.VersionedStruct('format', {
   0: { // Distance-based, no mapping

--- a/src/tables/directory.js
+++ b/src/tables/directory.js
@@ -1,5 +1,5 @@
 import * as r from 'restructure';
-import Tables from './';
+import Tables from './index.js';
 
 let TableEntry = new r.Struct({
   tag:        new r.String(4),

--- a/src/tables/index.js
+++ b/src/tables/index.js
@@ -1,20 +1,20 @@
 // @ts-check
 
 /**
- * @type {Record<import('./types').TableTag, any>}
+ * @type {Record<import('./types.js').TableTag, any>}
  */
 const tables = {};
 export default tables;
 
 // Required Tables
-import cmap from './cmap';
-import head from './head';
-import hhea from './hhea';
-import hmtx from './hmtx';
-import maxp from './maxp';
-import name from './name';
-import OS2 from './OS2';
-import post from './post';
+import cmap from './cmap.js';
+import head from './head.js';
+import hhea from './hhea.js';
+import hmtx from './hmtx.js';
+import maxp from './maxp.js';
+import name from './name.js';
+import OS2 from './OS2.js';
+import post from './post.js';
 
 tables.cmap = cmap;
 tables.head = head;
@@ -27,11 +27,11 @@ tables.post = post;
 
 
 // TrueType Outlines
-import cvt from './cvt';
-import fpgm from './fpgm';
-import loca from './loca';
-import prep from './prep';
-import glyf from './glyf';
+import cvt from './cvt.js';
+import fpgm from './fpgm.js';
+import loca from './loca.js';
+import prep from './prep.js';
+import glyf from './glyf.js';
 
 tables.fpgm = fpgm;
 tables.loca = loca;
@@ -41,8 +41,8 @@ tables.glyf = glyf;
 
 
 // PostScript Outlines
-import CFFFont from '../cff/CFFFont';
-import VORG from './VORG';
+import CFFFont from '../cff/CFFFont.js';
+import VORG from './VORG.js';
 
 tables['CFF '] = CFFFont;
 tables['CFF2'] = CFFFont;
@@ -50,10 +50,10 @@ tables.VORG = VORG;
 
 
 // Bitmap Glyphs
-import EBLC from './EBLC';
-import sbix from './sbix';
-import COLR from './COLR';
-import CPAL from './CPAL';
+import EBLC from './EBLC.js';
+import sbix from './sbix.js';
+import COLR from './COLR.js';
+import CPAL from './CPAL.js';
 
 tables.EBLC = EBLC;
 tables.CBLC = tables.EBLC;
@@ -63,11 +63,11 @@ tables.CPAL = CPAL;
 
 
 // Advanced OpenType Tables
-import BASE from './BASE';
-import GDEF from './GDEF';
-import GPOS from './GPOS';
-import GSUB from './GSUB';
-import JSTF from './JSTF';
+import BASE from './BASE.js';
+import GDEF from './GDEF.js';
+import GPOS from './GPOS.js';
+import GSUB from './GSUB.js';
+import JSTF from './JSTF.js';
 
 tables.BASE = BASE;
 tables.GDEF = GDEF;
@@ -76,20 +76,20 @@ tables.GSUB = GSUB;
 tables.JSTF = JSTF;
 
 // OpenType variations tables
-import HVAR from './HVAR';
+import HVAR from './HVAR.js';
 
 tables.HVAR = HVAR;
 
 // Other OpenType Tables
-import DSIG from './DSIG';
-import gasp from './gasp';
-import hdmx from './hdmx';
-import kern from './kern';
-import LTSH from './LTSH';
-import PCLT from './PCLT';
-import VDMX from './VDMX';
-import vhea from './vhea';
-import vmtx from './vmtx';
+import DSIG from './DSIG.js';
+import gasp from './gasp.js';
+import hdmx from './hdmx.js';
+import kern from './kern.js';
+import LTSH from './LTSH.js';
+import PCLT from './PCLT.js';
+import VDMX from './VDMX.js';
+import vhea from './vhea.js';
+import vmtx from './vmtx.js';
 
 tables.DSIG = DSIG;
 tables.gasp = gasp;
@@ -103,14 +103,14 @@ tables.vmtx = vmtx;
 
 
 // Apple Advanced Typography Tables
-import avar from './avar';
-import bsln from './bsln';
-import feat from './feat';
-import fvar from './fvar';
-import gvar from './gvar';
-import just from './just';
-import morx from './morx';
-import opbd from './opbd';
+import avar from './avar.js';
+import bsln from './bsln.js';
+import feat from './feat.js';
+import fvar from './fvar.js';
+import gvar from './gvar.js';
+import just from './just.js';
+import morx from './morx.js';
+import opbd from './opbd.js';
 
 tables.avar = avar;
 tables.bsln = bsln;

--- a/src/tables/just.js
+++ b/src/tables/just.js
@@ -1,5 +1,5 @@
 import * as r from 'restructure';
-import { LookupTable, StateTable1 } from './aat';
+import { LookupTable, StateTable1 } from './aat.js';
 
 let ClassTable = new r.Struct({
   length: r.uint16,

--- a/src/tables/morx.js
+++ b/src/tables/morx.js
@@ -1,5 +1,5 @@
 import * as r from 'restructure';
-import { UnboundedArray, LookupTable, StateTable } from './aat';
+import { UnboundedArray, LookupTable, StateTable } from './aat.js';
 
 let LigatureData = {
   action: r.uint16

--- a/src/tables/name.js
+++ b/src/tables/name.js
@@ -1,5 +1,5 @@
 import * as r from 'restructure';
-import {getEncoding, LANGUAGES} from '../encodings';
+import {getEncoding, LANGUAGES} from '../encodings.js';
 
 let NameRecord = new r.Struct({
   platformID: r.uint16,

--- a/src/tables/opbd.js
+++ b/src/tables/opbd.js
@@ -1,5 +1,5 @@
 import * as r from 'restructure';
-import { LookupTable } from './aat';
+import { LookupTable } from './aat.js';
 
 let OpticalBounds = new r.Struct({
   left: r.int16,

--- a/src/tables/variations.js
+++ b/src/tables/variations.js
@@ -1,4 +1,4 @@
-import {Feature} from './opentype';
+import {Feature} from './opentype.js';
 import * as r from 'restructure';
 
 /*******************

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,3 @@
+// Workaround for Parcel module resolution issue: JS files cannot resolve TS files with `*.js` extension.
+
+export * from './types.ts';

--- a/src/utils/clone.js
+++ b/src/utils/clone.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { AssertionError } from '../errors';
+import { AssertionError } from '../errors.js';
 import { isPrimitive } from './primitive.js';
 
 /**

--- a/src/utils/deep-equal.js
+++ b/src/utils/deep-equal.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { AssertionError } from '../errors';
+import { AssertionError } from '../errors.js';
 import { isPrimitive } from './primitive.js';
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "experimentalDecorators": true,
     "allowJs": true,
     "checkJs": false,


### PR DESCRIPTION
fontkit が提供する `*.d.ts` ファイルにて relative import paths にファイル拡張子が付いていなかったため、利用側（pdf-lib 等）が native ESM である場合に fontkit の型定義についてうまくモジュール解決できないケースがあった。

これを改善するため、ソースコード全体において、relative import paths で拡張子 `*.js` を明示的に付与するように修正した。